### PR TITLE
fix(icons): correct `sprite.svg` output

### DIFF
--- a/other/build-icons.ts
+++ b/other/build-icons.ts
@@ -132,7 +132,7 @@ async function generateSvgSprite({
     files.map(async (file) => {
       const input = await readFile(join(inputDir, file), 'utf8')
       const transformed = rewriter.transform(new Response(input))
-      return transformed
+      return transformed.text()
     }),
   )
 


### PR DESCRIPTION
closes: #18

## Test Plan

The generated `sprite.svg` is correct.

## Checklist

- [x] Tests updated
- [x] Docs updated
